### PR TITLE
enable demo to be run on heterogeneous robot teams

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -88,10 +88,6 @@ if __name__ == '__main__':
     
     if not args.skip_map:
         
-        # TODO: support including different data params for different runs
-        # currently can only use the same data params for all runs
-        args.run = None
-        
         for i, run in enumerate(data_params.runs):
             if args.skip_indices and i in args.skip_indices:
                 continue
@@ -104,7 +100,21 @@ if __name__ == '__main__':
                 os.environ[data_params.run_env] = run
             
             print(f"Mapping: {run}")
-            mapping.mapping(args)
+            mapping_viz_params = \
+                mapping.VisualizationParams(
+                    viz_map=args.viz_map,
+                    viz_observations=args.viz_observations,
+                    viz_3d=args.viz_3d,
+                    vid_rate=args.vid_rate,
+                    save_img_data=args.save_img_data
+                )
+            mapping.mapping(
+                params_path=args.params,
+                output_path=args.output,
+                run_name=run,
+                max_time=args.max_time,
+                viz_params=mapping_viz_params
+            )
         
     if not args.skip_align:
         # TODO: support ground truth pose file for validation

--- a/demo/loop_closures.py
+++ b/demo/loop_closures.py
@@ -1,6 +1,6 @@
 import argparse
 
-from roman.align.params import SubmapAlignInputOutput, SubmapAlignParams
+from roman.params.submap_align_params import SubmapAlignInputOutput, SubmapAlignParams
 from roman.align.submap_align import submap_align
 
 if __name__ == '__main__':

--- a/demo/params/demo/offline_rpgo.yaml
+++ b/demo/params/demo/offline_rpgo.yaml
@@ -4,3 +4,4 @@ odom_t_std: 0.02 # 2 cm
 odom_r_std: 0.001745 # .1 deg
 lc_t_std: 2.0 # 2 m
 lc_r_std: 0.1745 # 10 deg
+sparsified: False

--- a/roman/align/results.py
+++ b/roman/align/results.py
@@ -11,7 +11,7 @@ from robotdatapy.data.pose_data import PoseData
 
 from roman.utils import transform_rm_roll_pitch
 from roman.map.map import ROMANMap, SubmapParams
-from roman.align.params import SubmapAlignInputOutput, SubmapAlignParams
+from roman.params.submap_align_params import SubmapAlignInputOutput, SubmapAlignParams
 
 from roman.object.segment import Segment
 

--- a/roman/align/submap_align.py
+++ b/roman/align/submap_align.py
@@ -22,7 +22,7 @@ from roman.map.map import Submap, SubmapParams, submaps_from_roman_map, load_rom
 from roman.align.object_registration import InsufficientAssociationsException
 from roman.align.dist_reg_with_pruning import GravityConstraintError
 from roman.utils import object_list_bounds, transform_rm_roll_pitch
-from roman.align.params import SubmapAlignParams, SubmapAlignInputOutput
+from roman.params.submap_align_params import SubmapAlignParams, SubmapAlignInputOutput
 from roman.align.results import save_submap_align_results, SubmapAlignResults
 
 OVERLAP_EPS = 0.1

--- a/roman/map/map.py
+++ b/roman/map/map.py
@@ -11,7 +11,7 @@ import json
 
 from robotdatapy.data.pose_data import PoseData
 
-from roman.align.params import SubmapAlignParams
+from roman.params.submap_align_params import SubmapAlignParams
 from roman.object.segment import Segment, SegmentMinimalData
 from roman.utils import transform_rm_roll_pitch
 

--- a/roman/params/data_params.py
+++ b/roman/params/data_params.py
@@ -100,7 +100,7 @@ class PoseDataParams:
             else:
                 raise ValueError("Invalid string.")
         elif param_dict['input_type'] == 'tf':
-            img_file_path = expandvars_recursive(self.params["img_data"]["path"])
+            img_file_path = expandvars_recursive(self.params_dict["path"])
             T = PoseData.static_tf_from_bag(
                 expandvars_recursive(img_file_path), 
                 expandvars_recursive(param_dict['parent']), 
@@ -135,17 +135,26 @@ class DataParams:
     def from_yaml(cls, yaml_path: str, run: str = None):
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
-        if run is not None:
-            data = data[run]
+        if run is None:
+            return cls(
+                None, None, None,
+                dt=data['dt'] if 'dt' in data else 1/6,
+                runs=data['runs'] if 'runs' in data else None,
+                run_env=data['run_env'] if 'run_env' in data else None
+            )
+        elif run in data:
+            run_data = data[run]
+        else:
+            run_data = data
         return cls(
-            ImgDataParams.from_dict(data['img_data']),
-            ImgDataParams.from_dict(data['depth_data']),
-            PoseDataParams.from_dict(data['pose_data']),
-            dt=data['dt'] if 'dt' in data else 1/6,
+            ImgDataParams.from_dict(run_data['img_data']),
+            ImgDataParams.from_dict(run_data['depth_data']),
+            PoseDataParams.from_dict(run_data['pose_data']),
+            dt=run_data['dt'] if 'dt' in run_data else 1/6,
             runs=data['runs'] if 'runs' in data else None,
             run_env=data['run_env'] if 'run_env' in data else None,
-            time_params=data['time_params'] if 'time_params' in data else None,
-            kitti=data['kitti'] if 'kitti' in data else False
+            time_params=run_data['time_params'] if 'time_params' in run_data else None,
+            kitti=run_data['kitti'] if 'kitti' in run_data else False
         )
         
     @cached_property

--- a/roman/params/fastsam_params.py
+++ b/roman/params/fastsam_params.py
@@ -71,7 +71,7 @@ class FastSAMParams:
     def from_yaml(cls, yaml_path: str, run: str = None):
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
-        if run is not None:
+        if run is not None and run in data:
             data = data[run]
         return cls(**data)
     

--- a/roman/params/mapper_params.py
+++ b/roman/params/mapper_params.py
@@ -57,6 +57,6 @@ class MapperParams():
     def from_yaml(cls, yaml_path: str, run: str = None):
         with open(yaml_path) as f:
             data = yaml.safe_load(f)
-        if run is not None:
+        if run is not None and run in data:
             data = data[run]
         return cls(**data)

--- a/roman/params/offline_rpgo_params.py
+++ b/roman/params/offline_rpgo_params.py
@@ -1,3 +1,15 @@
+###########################################################
+#
+# offline_rpgo_params.py
+#
+# Params for ROMAN offline RPGO SLAM.
+#
+# Authors: Mason Peterson
+#
+# Jan. 15, 2025
+#
+###########################################################
+
 import numpy as np
 
 from dataclasses import dataclass
@@ -15,7 +27,9 @@ class OfflineRPGOParams:
     # loop closure covariance params
     lc_t_std: float = 0.5
     lc_r_std: float = np.deg2rad(0.5)
-
+    
+    # sparse or dense
+    sparsified: bool = True
 
     @classmethod
     def from_yaml(cls, yaml_file):

--- a/roman/params/submap_align_params.py
+++ b/roman/params/submap_align_params.py
@@ -1,3 +1,15 @@
+###########################################################
+#
+# submap_align_params.py
+#
+# Params for ROMAN object registration.
+#
+# Authors: Mason Peterson
+#
+# Jan. 15, 2025
+#
+###########################################################
+
 import numpy as np
 
 from dataclasses import dataclass, field

--- a/roman/viz.py
+++ b/roman/viz.py
@@ -77,6 +77,7 @@ def visualize_observations_on_img(t, img, mapper, observations, reprojected_bbox
         cv.rectangle(img_fastsam, np.array([bbox[0][0], bbox[0][1]]).astype(np.int32), 
                     np.array([bbox[1][0], bbox[1][1]]).astype(np.int32), color=rand_color.tolist(), thickness=2)
     
+# TODO: rename, this is confusing. This is visualizing the 3D world (does not write on top of another image)
 def visualize_3d_on_img(t: float, pose_flu: np.ndarray, mapper: Mapper) -> np.ndarray:
     """
     Visualizes a 3D map onto an image (with camera params used by the mapper).


### PR DESCRIPTION
Previously the same data.yaml params had to be used for all robots (meaning RGB-D images and pose information had to be of the same format).

Changes to the params python classes (data_params.py, fastsam_params.py, and mapper_params.py) enable different image and pose information formats.