### PR TITLE
Feature/add lidar depth

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -55,8 +55,8 @@ If the pose is recorded using `/tf` topic rather tha a Pose or Odometry message,
 ```
 type: bag_tf
 path: <bag file path>
-parent: <parent frame_id>
-child: <child frame_id>
+parent_frame: <parent frame_id>
+child_frame: <child frame_id>
 inv: <Whether the transformation from /tf should be inverted or not>
 ```
 

--- a/roman/map/align_pointcloud.py
+++ b/roman/map/align_pointcloud.py
@@ -61,8 +61,6 @@ class AlignPointCloud():
         pointcloud_time = pcl.header.stamp.sec + 1e-9 * pcl.header.stamp.nanosec
         img_time = img_header.stamp.sec + 1e-9 * img_header.stamp.nanosec
 
-        print(f'times | pointcloud: {pointcloud_time}, img: {img_time}')
-
         # calculate dynamic transform between robot at time of image and robot at time of pointcloud
         T_W_camera_pointcloud_time = self.camera_pose_data.T_WB(pointcloud_time)
         T_W_camera_image_time = self.camera_pose_data.T_WB(img_time)

--- a/roman/map/align_pointcloud.py
+++ b/roman/map/align_pointcloud.py
@@ -1,0 +1,124 @@
+###########################################################
+#
+# align_pointcloud.py
+#
+# A class to align a point cloud with a camera & project onto the camera image frame
+#
+# Authors: Qingyuan Li
+#
+# January 27. 2025
+#
+###########################################################
+
+
+from robotdatapy.data import PointCloudData, ImgData, PoseData
+import numpy as np
+import cv2 as cv
+from roman.utils import expandvars_recursive
+
+class AlignPointCloud():
+    pointcloud_data: PointCloudData
+    img_data: ImgData
+    pose_data: PoseData
+    T_camera_rangesens_static: np.ndarray
+
+    def __init__(self, pointcloud_data: PointCloudData, img_data: ImgData, pose_data: PoseData, tf_bag_path: str, odombase_frame: str):
+        """
+        Class for aligning a point cloud with a camera and projecting the point cloud onto the camera's image frame
+
+        Args:
+            pointcloud_data (PointCloudData): point cloud data class
+            img_data (ImgData): image data class
+            pose_data (PoseData): pose data class
+            tf_bag_path (str):  path to bag with static tf data (needed to calculate static transform from
+                                camera to range sensor)
+        """
+        self.pointcloud_data = pointcloud_data
+        self.img_data = img_data
+        self.pose_data = pose_data
+
+        # calculate static transform from camera to range sensor
+        self.pointcloud_frame = pointcloud_data.pointcloud(pointcloud_data.times[0]).header.frame_id
+        self.camera_frame = img_data.img_header(img_data.times[0]).frame_id
+        self.img_shape = img_data.img(img_data.times[0]).shape[:2]
+        self.T_camera_rangesens_static = PoseData.any_static_tf_from_bag(expandvars_recursive(tf_bag_path), self.camera_frame, self.pointcloud_frame)
+        print('odombase frame:', odombase_frame)
+        self.T_odombase_rangesense_static = PoseData.any_static_tf_from_bag(expandvars_recursive(tf_bag_path), odombase_frame, self.pointcloud_frame)
+
+    def aligned_pointcloud(self, t: float):
+        """
+        Return the closest point cloud at time t, aligned to the camera frame
+
+        Args:
+            t (float): time to get closest point cloud to
+
+        Returns:
+            np.ndarray: (n, 3) array containing 3D point cloud in the frame of the camera (Z forward, Y down)
+        """
+        pcl = self.pointcloud_data.pointcloud(t)
+
+        img_header = self.img_data.img_header(t)
+
+        # get exact times of point cloud and image messages
+        pointcloud_time = pcl.header.stamp.sec + 1e-9 * pcl.header.stamp.nanosec
+        img_time = img_header.stamp.sec + 1e-9 * img_header.stamp.sec
+
+        print(f'times | pointcloud: {pointcloud_time}, img: {img_time}')
+
+        # calculate dynamic transform between robot at time of image and robot at time of pointcloud
+        T_W_odom_pointcloud_time = self.pose_data.T_WB(pointcloud_time, multiply=False)
+        T_W_odom_image_time = self.pose_data.T_WB(img_time, multiply=False)
+        T_W_rangesense_pointcloud_time = T_W_odom_pointcloud_time @ self.T_odombase_rangesense_static
+        T_W_rangesense_image_time = T_W_odom_image_time @ self.T_odombase_rangesense_static
+        T_img_cloud_dynamic = np.linalg.inv(T_W_rangesense_image_time) @ T_W_rangesense_pointcloud_time
+
+        # compose static and dynamic transforms to get approximately exact transform
+        # between camera at time of image and range sensor at time of point cloud
+        # T_camera_rangesens = self.T_camera_rangesens_static @ T_img_cloud_dynamic
+
+        T_camera_rangesens = self.T_camera_rangesens_static
+
+        # transform points into image frame
+        points = pcl.get_xyz()
+        points_h = np.hstack((points, np.ones((points.shape[0], 1))))
+        points_h_image_frame = points_h @ T_camera_rangesens.T
+        points_camera_frame = points_h_image_frame[:, :3]
+
+        # mask for points in front of camera (positive Z in camera frame)
+        in_front_mask = points_camera_frame[:, 2] >= 0
+        points_camera_frame_filtered = points_camera_frame[in_front_mask]
+
+        return points_camera_frame_filtered
+    
+    def projected_pointcloud(self, points_camera_frame):
+        """
+        Projects a 3D point cloud in the camera frame (from aligned_pointcloud) to 
+        the 2D image frame
+
+        Args:
+            points_camera_frame (np.ndarray): (n, 3) array containing 3D point cloud in the frame of the camera (Z forward, Y down)
+
+        Returns:
+            np.ndarray: (n, 2) array containing 2D projected points in (u, v) coordinates, order unchanged
+        """
+        # project point cloud onto 2D image
+        points_camera_frame_cv = points_camera_frame.reshape(-1, 1, 3)
+        points_2d_cv, _ = cv.projectPoints(points_camera_frame_cv, np.zeros(3), np.zeros(3), self.img_data.K, self.img_data.D)
+        points_2d = points_2d_cv.reshape((-1, 2))
+
+        return points_2d
+    
+    def filter_pointcloud_and_projection(self, points_camera_frame, points_2d):
+        """
+        Filters array of (u, v) coordinates in image frame and associated 3D point cloud by checking
+        that it is inside the associated rgb image frame bounds and casting to int
+
+        Args:
+            points_camera_frame (np.ndarray): (n, 3) array containing 3D point cloud in the frame of the camera (Z forward, Y down)
+            points_2d (np.ndarray): (n, 2) array containing 2D projected points in (u, v) coordinates, in same order
+        """
+        points_2d = np.round(points_2d).astype(int)
+        inside_frame = (points_2d[:, 0] >= 0) & (points_2d[:, 0] < self.img_shape[1]) & (points_2d[:, 1] >= 0) & (points_2d[:, 1] < self.img_shape[0])
+        points_camera_frame = points_camera_frame[inside_frame]
+        points_2d = points_2d[inside_frame]
+        return points_camera_frame, points_2d

--- a/roman/map/fastsam_wrapper.py
+++ b/roman/map/fastsam_wrapper.py
@@ -272,40 +272,40 @@ class FastSAMWrapper():
             ptcld = None
             if depth_data is not None:
                 if self.use_pointcloud:
-                    if False: # visualizations for debugging
-                        # point_cloud = o3d.geometry.PointCloud()
-                        # point_cloud.points = o3d.utility.Vector3dVector(pcl)
-                        # point_cloud.paint_uniform_color([1, 0, 0])
-                        # coordinate_frame = o3d.geometry.TriangleMesh.create_coordinate_frame(size=10.0)
+                    # if False: # visualizations for debugging
+                    #     # point_cloud = o3d.geometry.PointCloud()
+                    #     # point_cloud.points = o3d.utility.Vector3dVector(pcl)
+                    #     # point_cloud.paint_uniform_color([1, 0, 0])
+                    #     # coordinate_frame = o3d.geometry.TriangleMesh.create_coordinate_frame(size=10.0)
 
-                        # o3d.visualization.draw_geometries([point_cloud, coordinate_frame])
+                    #     # o3d.visualization.draw_geometries([point_cloud, coordinate_frame])
 
-                        import matplotlib.pyplot as plt
+                    #     import matplotlib.pyplot as plt
 
-                        img_shape = img.shape[:2]
-                        depth_image = np.zeros(img_shape, dtype=np.float32)
-                        depths = pcl[:, 2]
-                        MAX_DEPTH=15
+                    #     img_shape = img.shape[:2]
+                    #     depth_image = np.zeros(img_shape, dtype=np.float32)
+                    #     depths = pcl[:, 2]
+                    #     MAX_DEPTH=15
 
-                        for i in range(pcl_proj.shape[0]):
-                            u, v = pcl_proj[i]
-                            u, v = int(u), int(v)
-                            depth = depths[i]
-                            if 0 <= u < img_shape[1] and 0 <= v < img_shape[0] and depth <= MAX_DEPTH:
-                                depth = depths[i]
-                                depth_image[v, u] = depth
+                    #     for i in range(pcl_proj.shape[0]):
+                    #         u, v = pcl_proj[i]
+                    #         u, v = int(u), int(v)
+                    #         depth = depths[i]
+                    #         if 0 <= u < img_shape[1] and 0 <= v < img_shape[0] and depth <= MAX_DEPTH:
+                    #             depth = depths[i]
+                    #             depth_image[v, u] = depth
 
-                        depth_normalized = cv.normalize(depth_image, None, 0, 1, cv.NORM_MINMAX)
-                        depth_colored = cv.applyColorMap(((1 - depth_normalized) * 255).astype(np.uint8), cv.COLORMAP_JET)
-                        rgb_image_rgb = cv.cvtColor(img, cv.COLOR_BGR2RGB)
+                    #     depth_normalized = cv.normalize(depth_image, None, 0, 1, cv.NORM_MINMAX)
+                    #     depth_colored = cv.applyColorMap(((1 - depth_normalized) * 255).astype(np.uint8), cv.COLORMAP_JET)
+                    #     rgb_image_rgb = cv.cvtColor(img, cv.COLOR_BGR2RGB)
 
-                        overlay = depth_colored
-                        overlay[depth_image == 0] = rgb_image_rgb[depth_image == 0]
-                        plt.imshow(overlay)
-                        plt.show()
+                    #     overlay = depth_colored
+                    #     overlay[depth_image == 0] = rgb_image_rgb[depth_image == 0]
+                    #     plt.imshow(overlay)
+                    #     plt.show()
 
-                        # import ipdb
-                        # ipdb.set_trace()
+                    #     # import ipdb
+                    #     # ipdb.set_trace()
 
                     # get 3D points that project within the mask
                     inside_mask = mask[pcl_proj[:, 1], pcl_proj[:, 0]] == 1

--- a/roman/map/fastsam_wrapper.py
+++ b/roman/map/fastsam_wrapper.py
@@ -272,7 +272,7 @@ class FastSAMWrapper():
             ptcld = None
             if depth_data is not None:
                 if self.use_pointcloud:
-                    if True: # visualizations for debugging
+                    if False: # visualizations for debugging
                         # point_cloud = o3d.geometry.PointCloud()
                         # point_cloud.points = o3d.utility.Vector3dVector(pcl)
                         # point_cloud.paint_uniform_color([1, 0, 0])

--- a/roman/map/run.py
+++ b/roman/map/run.py
@@ -68,9 +68,8 @@ class ROMANMapRunner:
             self.pointcloud_data = self.data_params.load_pointcloud_data()
             self.align_pointcloud = AlignPointCloud(pointcloud_data=self.pointcloud_data,
                                                     img_data=self.img_data,
-                                                    pose_data=self.camera_pose_data,
-                                                    tf_bag_path=self.data_params.pose_data_params.params_dict['path'],
-                                                    odombase_frame=self.data_params.pose_data_params.odombase_frame) # TODO: clean up?
+                                                    camera_pose_data=self.camera_pose_data,
+                                                    tf_bag_path=self.data_params.pose_data_params.params_dict['path']) # TODO: clean up?
         else:
             if verbose: print("Loading depth data for time range {}...".format(self.time_range))
             self.depth_data = self.data_params.load_depth_data()

--- a/roman/map/run.py
+++ b/roman/map/run.py
@@ -4,7 +4,7 @@
 #
 # A class for processing ROMAN mapping
 #
-# Authors: Mason Peterson, Yulun Tian, Lucas Jia
+# Authors: Mason Peterson, Yulun Tian, Lucas Jia, Qingyuan Li
 #
 # Dec. 21, 2024
 #
@@ -30,6 +30,7 @@ from roman.viz import visualize_map_on_img, visualize_observations_on_img, visua
 from roman.map.mapper import Mapper
 from roman.map.fastsam_wrapper import FastSAMWrapper
 from roman.map.map import ROMANMap
+from roman.map.align_pointcloud import AlignPointCloud
 from roman.params.data_params import DataParams
 from roman.params.mapper_params import MapperParams
 from roman.params.fastsam_params import FastSAMParams
@@ -59,14 +60,26 @@ class ROMANMapRunner:
             self.t0 = self.img_data.t0
             self.tf = self.img_data.tf
 
-        if verbose: print("Loading depth data for time range {}...".format(self.time_range))
-        self.depth_data = self.data_params.load_depth_data()
-
         if verbose: print("Loading pose data...")
         self.camera_pose_data = self.data_params.load_pose_data()
+
+        if self.data_params.use_pointcloud:
+            if verbose: print("Loading point cloud data for time range {}...".format(self.time_range))
+            self.pointcloud_data = self.data_params.load_pointcloud_data()
+            self.align_pointcloud = AlignPointCloud(pointcloud_data=self.pointcloud_data,
+                                                    img_data=self.img_data,
+                                                    pose_data=self.camera_pose_data,
+                                                    tf_bag_path=self.data_params.pose_data_params.params_dict['path'],
+                                                    odombase_frame=self.data_params.pose_data_params.odombase_frame) # TODO: clean up?
+        else:
+            if verbose: print("Loading depth data for time range {}...".format(self.time_range))
+            self.depth_data = self.data_params.load_depth_data()
         
         if verbose: print("Setting up FastSAM...")
-        self.fastsam = FastSAMWrapper.from_params(self.fastsam_params, self.depth_data.camera_params)
+        self.fastsam = FastSAMWrapper.from_params(params=self.fastsam_params,
+                                                  depth_cam_params=self.img_data.camera_params if self.data_params.use_pointcloud else 
+                                                                   self.depth_data.camera_params,
+                                                  use_pointcloud=self.data_params.use_pointcloud) # TODO: clean up?
 
         # TODO: start here
         if verbose: print("Setting up ROMAN mapper...")
@@ -110,13 +123,18 @@ class ROMANMapRunner:
         try:
             img_t = self.img_data.nearest_time(t)
             img = self.img_data.img(img_t)
-            img_depth = self.depth_data.img(img_t)
-            pose_odom_camera = self.camera_pose_data.T_WB(img_t)
+            T_odom_camera = self.camera_pose_data.T_WB(img_t)
+            if self.data_params.use_pointcloud:
+                pcl = self.align_pointcloud.aligned_pointcloud(img_t)
+                pcl_proj  = self.align_pointcloud.projected_pointcloud(pcl)
+                depth_data = self.align_pointcloud.filter_pointcloud_and_projection(pcl, pcl_proj)
+            else:
+                depth_data = self.depth_data.img(img_t)
         except NoDataNearTimeException:
             return None, None, None, None
         
-        observations = self.fastsam.run(img_t, pose_odom_camera, img, img_depth=img_depth)
-        return img_t, observations, pose_odom_camera, img
+        observations = self.fastsam.run(img_t, T_odom_camera, img, depth_data=depth_data)
+        return img_t, observations, T_odom_camera, img
 
     def update_segment_track(self, t, observations, pose_odom_camera, img): 
 

--- a/roman/params/data_params.py
+++ b/roman/params/data_params.py
@@ -169,8 +169,8 @@ class DataParams:
             ImgDataParams.from_dict(run_data['depth_data']) if 'depth_data' in run_data else None,
             PointCloudDataParams.from_dict(run_data['pointcloud_data']) if 'pointcloud_data' in run_data else None,
             PoseDataParams.from_dict(run_data['pose_data']),
-            use_pointcloud=data['depth_source'] == 'pointcloud' if 'depth_source' in data else \
-                          (data['use_pointcloud'] if 'use_pointcloud' in data else False),
+            use_pointcloud=run_data['depth_source'] == 'pointcloud' if 'depth_source' in run_data else \
+                          (run_data['use_pointcloud'] if 'use_pointcloud' in run_data else False),
             dt=run_data['dt'] if 'dt' in run_data else 1/6,
             runs=data['runs'] if 'runs' in data else None,
             run_env=data['run_env'] if 'run_env' in data else None,

--- a/roman/params/data_params.py
+++ b/roman/params/data_params.py
@@ -161,7 +161,7 @@ class DataParams:
                 run_env=data['run_env'] if 'run_env' in data else None
             )
         elif run in data:
-            run_data = data[run]
+            run_data = {**data, **data[run]}
         else:
             run_data = data
         return cls(


### PR DESCRIPTION
I did change how the params files are handled to reduce repetition, so changes might be breaking:

- `run_data = {**data, **data[run]}` in data_params.py makes it possible to have params shared between runs AND params specific to runs (e.g. same robot topics, different timestamps for different runs).

- The time params format was redundant, I changed it so all that is needed to set the start & end time is:
```  
time:
    t0: ?
    tf: ?
    relative: ?
```

- To toggle lidar globally or for each run: `use_pointcloud: True` or `depth_source: 'pointcloud'`

Example showing these changes:
```
runs: ['a', 'b']
run_env: "ROBOT"
dt: 0.16666666666666667

'a':
    time: 
        ...
    use_pointcloud: False
'b':
    time:
        ...
    use_pointcloud: True

pointcloud_data:
    path: ${BAGS_PATH}/${ROBOT}.bag
    topic: /lidar_points
```

Still needs official documentation & probably some cleanup, but wanted to start the merging process.
