### PR TITLE
Feature/triangle mask

### DIFF
--- a/roman/align/submap_align.py
+++ b/roman/align/submap_align.py
@@ -25,8 +25,6 @@ from roman.utils import object_list_bounds, transform_rm_roll_pitch
 from roman.params.submap_align_params import SubmapAlignParams, SubmapAlignInputOutput
 from roman.align.results import save_submap_align_results, SubmapAlignResults
 
-OVERLAP_EPS = 0.1
-
 def submap_align(sm_params: SubmapAlignParams, sm_io: SubmapAlignInputOutput):
     """
     Breaks maps into submaps and attempts to align each submap from one map with each submap from the second map.

--- a/roman/params/data_params.py
+++ b/roman/params/data_params.py
@@ -29,6 +29,7 @@ class ImgDataParams:
     camera_info_topic: str
     compressed: bool = True
     compressed_rvl: bool = False
+    compressed_encoding: str = 'passthrough'
     
     @classmethod
     def from_dict(cls, params_dict: dict):
@@ -227,7 +228,7 @@ class DataParams:
                 time_range=self.time_range,
                 compressed=img_data_params.compressed,
                 compressed_rvl=img_data_params.compressed_rvl,
-                # compressed_encoding='bgr8'
+                compressed_encoding=img_data_params.compressed_encoding
             )
             img_data.extract_params(expandvars_recursive(img_data_params.camera_info_topic))
         return img_data

--- a/roman/params/fastsam_params.py
+++ b/roman/params/fastsam_params.py
@@ -13,7 +13,7 @@
 from dataclasses import dataclass
 import yaml
 
-from typing import Tuple
+from typing import Tuple, List
 
 @dataclass
 class FastSAMParams:
@@ -42,6 +42,11 @@ class FastSAMParams:
         yolo_imgsz (Tuple[int, int]): size of the YOLO image
         depth_scale (float): depth scale factor for processing depth images
         max_depth (float): maximum depth before rejecting observation points
+        triangle_ignore_masks (List[Tuple[Tuple[int, int], Tuple[int, int], Tuple[int, int]]]): 
+            list of triangles to ignore. Given as a list of triples where each element of the 
+            triple is a pixel coordinates of a triangle corner. Coordinates are (x,y) in the 
+            rotated image.
+
 
     Returns:
         _type_: _description_
@@ -66,6 +71,7 @@ class FastSAMParams:
     yolo_imgsz: Tuple[int, int] = (256, 256)
     depth_scale: float = 1e3
     max_depth: float = 7.5
+    triangle_ignore_masks: List[Tuple[Tuple[int,int], Tuple[int,int], Tuple[int,int]]] = None
     
     @classmethod
     def from_yaml(cls, yaml_path: str, run: str = None):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'matplotlib', 
         'gtsam',
         'scikit-image',
-        'open3d==0.18.0',
+        'open3d>=0.18.0',
         'yolov7-package',
         'shapely',
         'opencv-python>=4.6.0',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'open3d==0.18.0',
         'yolov7-package',
         'shapely',
-        'opencv-python',
+        'opencv-python>=4.6.0',
         'pyyaml',
         'torch==2.4.0',
         'torchvision==0.19.0',


### PR DESCRIPTION
Add feature to filter out triangles (multiple can be used to make more complex shapes) in FastSAM. This can be used to filter out part of a robot body that is in view of the camera image.