### PR TITLE
Fix/submap param setting

### DIFF
--- a/roman/align/roman_registration.py
+++ b/roman/align/roman_registration.py
@@ -30,7 +30,7 @@ class ROMANParams:
     semantics_dim = 0
 
     cos_min: float = 0.85
-    cos_max: float = 0.95
+    cos_max: float = 1.0
     epsilon_shape: float = None
 
 

--- a/roman/params/submap_align_params.py
+++ b/roman/params/submap_align_params.py
@@ -46,7 +46,7 @@ class SubmapAlignParams:
     # registration params
     sigma: float = 0.4
     epsilon: float = 0.6
-    mindist: float = 0.4
+    mindist: float = 0.2
     epsilon_shape: float = 0.0
     ransac_iter: int = int(1e6)
     cosine_min: float = 0.85

--- a/roman/params/submap_align_params.py
+++ b/roman/params/submap_align_params.py
@@ -74,8 +74,8 @@ class SubmapAlignParams:
             roman_params.point_dim = self.dim
             roman_params.sigma = self.sigma
             roman_params.epsilon = self.epsilon
-            roman_params.min_dist = self.mindist
-            roman_params.fusion = sim_fusion_method
+            roman_params.mindist = self.mindist
+            roman_params.fusion_method = sim_fusion_method
 
             roman_params.gravity = self.method in ['gravity', 'pcavolgrav', 'extentvolgrav', 'roman', 'sevg', 'semanticgrav']
             roman_params.volume = self.method in ['pcavolgrav', 'extentvolgrav', 'roman', 'sevg', 'spv']


### PR DESCRIPTION
mindist and fusion_method were not being set correctly. Fixed here.

TODO: having two sets of params for the roman registration is pretty messy. This should be cleaned up.