### PR TITLE
Handle ground truth files for individually named runs

### DIFF
--- a/demo/association_vid.py
+++ b/demo/association_vid.py
@@ -157,7 +157,8 @@ if __name__ == '__main__':
     print(f"Loading pose data...")
     pose_data = []
     for i in range(2):
-        os.environ[data_params[i].run_env] = args.runs[i]
+        if data_params[i].run_env is not None:
+            os.environ[data_params[i].run_env] = args.runs[i]
         # for now, use the sparser trajectory from roman map for faster load time
         if args.original_pose_data:
             pose_data.append(data_params[i].load_pose_data())
@@ -171,7 +172,8 @@ if __name__ == '__main__':
     print(f"Loading image data...")
     img_data = []
     for i in range(2):
-        os.environ[data_params[i].run_env] = args.runs[i]
+        if data_params[i].run_env is not None:
+            os.environ[data_params[i].run_env] = args.runs[i]
         img_data.append(data_params[i].load_img_data())
 
     fc = cv.VideoWriter_fourcc(*"mp4v")
@@ -221,7 +223,16 @@ if __name__ == '__main__':
                             [0., f, o3d_h/2],
                             [0., 0., 1.]])
 
-        
+        edge_mat = o3d.visualization.rendering.MaterialRecord()
+        edge_mat.shader = "unlitLine"
+        edge_mat.line_width = 5.0
+        pt_mat = o3d.visualization.rendering.MaterialRecord()
+        pt_mat.point_size = 5.0
+        for i, obj in enumerate(pcd_lists[0] + pcd_lists[1]):
+            scene.add_geometry(f"pcd-{i}", obj, pt_mat)
+        for i, edg in enumerate(edges):
+            scene.add_geometry(f"edge-{i}", edg, edge_mat)
+
     print("Creating video...")
     for t in tqdm.tqdm(np.arange(0.0, min_time_range, 1/vid_params.fps)):
         
@@ -296,19 +307,7 @@ if __name__ == '__main__':
             camera_pose = camera_pose @ behind_camera
             renderer.setup_camera(o3d_K, np.linalg.inv(camera_pose), o3d_w, o3d_h)
 
-            edge_mat = o3d.visualization.rendering.MaterialRecord()
-            edge_mat.shader = "unlitLine"
-            edge_mat.line_width = 5.0
-            pt_mat = o3d.visualization.rendering.MaterialRecord()
-            pt_mat.point_size = 5.0
-
-            for i, obj in enumerate(pcd_lists[0] + pcd_lists[1]):
-                scene.add_geometry(f"pcd-{i}", obj, pt_mat)
-            for i, edg in enumerate(edges):
-                scene.add_geometry(f"edge-{i}", edg, edge_mat)
-            o3d_img = renderer.render_to_image()
-            o3d_img = cv.cvtColor(np.asarray(o3d_img), cv.COLOR_RGB2BGR)
-            scene.clear_geometry()
+            o3d_img = cv.cvtColor(np.asarray(renderer.render_to_image()), cv.COLOR_RGB2BGR)
 
             viz_img[:, :o3d_w] = o3d_img
             

--- a/roman/align/results.py
+++ b/roman/align/results.py
@@ -13,6 +13,7 @@ from robotdatapy.data.pose_data import PoseData
 from roman.utils import transform_rm_roll_pitch
 from roman.map.map import ROMANMap, SubmapParams, submaps_from_roman_map
 from roman.params.submap_align_params import SubmapAlignInputOutput, SubmapAlignParams
+from roman.offline_rpgo.g2o_and_time_to_pose_data import load_gt_pose_data
 from roman.object.segment import Segment
 
 @dataclass
@@ -258,12 +259,10 @@ def submaps_from_align_results(results: SubmapAlignResults, gt_paths: Tuple[str,
     gt_pose_data = []
     if gt_files != [None, None]:
         for i, yaml_file in enumerate(gt_files):
-            if results.submap_io.robot_env is not None:
-                os.environ[results.submap_io.robot_env] = results.submap_io.robot_names[i]
-            if 'csv' in yaml_file:
-                gt_pose_data.append(PoseData.from_kmd_gt_csv(yaml_file))
-            else:
-                gt_pose_data.append(PoseData.from_yaml(yaml_file))
+            run_name = results.submap_io.robot_names[i] if results.submap_io.robot_names is not None else None
+            if run_name is not None and results.submap_io.robot_env is not None:
+                os.environ[results.submap_io.robot_env] = run_name
+            gt_pose_data.append(load_gt_pose_data(yaml_file, run_name=run_name))
             gt_pose_data[-1].time_tol = 100.0
     else:
         gt_pose_data = [None, None]

--- a/roman/align/submap_align.py
+++ b/roman/align/submap_align.py
@@ -48,6 +48,8 @@ def submap_align(sm_params: SubmapAlignParams, sm_io: SubmapAlignInputOutput):
             # load yaml file
             with open(os.path.expanduser(yaml_file), 'r') as f:
                 gt_pose_args = yaml.safe_load(f)
+            if sm_io.robot_env in gt_pose_args:
+                gt_pose_args = gt_pose_args[sm_io.robot_env]
             if gt_pose_args['type'] == 'bag':
                 gt_pose_data[i] = PoseData.from_bag(**{k: v for k, v in gt_pose_args.items() if k != 'type'})
             elif gt_pose_args['type'] == 'csv':

--- a/roman/align/submap_align.py
+++ b/roman/align/submap_align.py
@@ -48,8 +48,8 @@ def submap_align(sm_params: SubmapAlignParams, sm_io: SubmapAlignInputOutput):
             # load yaml file
             with open(os.path.expanduser(yaml_file), 'r') as f:
                 gt_pose_args = yaml.safe_load(f)
-            if sm_io.robot_env in gt_pose_args:
-                gt_pose_args = gt_pose_args[sm_io.robot_env]
+            if sm_io.robot_names[i] in gt_pose_args:
+                gt_pose_args = gt_pose_args[sm_io.robot_names[i]]
             if gt_pose_args['type'] == 'bag':
                 gt_pose_data[i] = PoseData.from_bag(**{k: v for k, v in gt_pose_args.items() if k != 'type'})
             elif gt_pose_args['type'] == 'csv':

--- a/roman/offline_rpgo/g2o_and_time_to_pose_data.py
+++ b/roman/offline_rpgo/g2o_and_time_to_pose_data.py
@@ -96,11 +96,13 @@ def combine_multi_est_and_gt_pose_data(est: List[PoseData], gt: List[PoseData]) 
     
     return concatentate_pose_data(est), concatentate_pose_data(gt)
 
-def load_gt_pose_data(gt_file):
+def load_gt_pose_data(gt_file, run_name=None):
     if 'csv' in gt_file:
-        return PoseData.from_kmd_gt_csv(gt_file) 
+        return PoseData.from_kmd_gt_csv(gt_file)
     with open(os.path.expanduser(gt_file), 'r') as f:
         gt_pose_args = yaml.safe_load(f)
+    if run_name is not None and run_name in gt_pose_args:
+        gt_pose_args = gt_pose_args[run_name]
     if gt_pose_args['type'] == 'bag':
         return PoseData.from_bag(**{k: v for k, v in gt_pose_args.items() if k != 'type'})
     elif gt_pose_args['type'] == 'csv':
@@ -130,9 +132,10 @@ def gt_csv_est_g2o_to_pose_data(est_g2o_file: str, est_time_file: str,
     
     pose_data_gt = []
     for i in sorted(gt_csv_files.keys()):
-        if run_names is not None and run_env is not None:
-            os.environ[run_env] = run_names[i]
-        pose_data_gt.append(load_gt_pose_data(gt_csv_files[i]))
+        run_name = run_names[i] if run_names is not None else None
+        if run_name is not None and run_env is not None:
+            os.environ[run_env] = run_name
+        pose_data_gt.append(load_gt_pose_data(gt_csv_files[i], run_name=run_name))
     pose_data_est = [g2o_and_time_to_pose_data(est_g2o_file, est_time_file, i)
                      for i in sorted(gt_csv_files.keys())]
     


### PR DESCRIPTION
Mapping in `demo.py` allows `data.yaml` to individually name runs (i.e., not using `run_env`). These changes support individually named runs for the rest of the demo pipeline.

Also moves rendering geometry in the association videos to outside the for loop, to avoid segfaults from memory usage in rendering loop.